### PR TITLE
Feature/#7 CustomGenericSingleton

### DIFF
--- a/Client/Assets/Scripts.meta
+++ b/Client/Assets/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 52ebd77ce872ce745ab3fe1618974e67
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Client/Assets/Scripts/Managers.meta
+++ b/Client/Assets/Scripts/Managers.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 10e72dfb78aed404dbf381cd34d36f4e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Client/Assets/Scripts/Utils.meta
+++ b/Client/Assets/Scripts/Utils.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 18ef28c820249cc4a90581b917dce541
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Client/Assets/Scripts/Utils/CustomSingleton.cs
+++ b/Client/Assets/Scripts/Utils/CustomSingleton.cs
@@ -1,0 +1,44 @@
+using UnityEngine;
+
+public class CustomSingleton<T> : MonoBehaviour where T : MonoBehaviour
+{
+    // Check to see if we're about to be destroyed
+    private static bool m_ShuttingDown = false;
+    private static T m_Instance;
+
+    public static T Instance
+    {
+        get
+        {
+            if (m_ShuttingDown)
+            {
+                return null;
+            }
+
+            if (m_Instance == null)
+            {
+                m_Instance = (T)FindObjectOfType(typeof(T));
+
+                if (m_Instance == null)
+                {
+                    GameObject singletonObject = new GameObject { name = "@" + typeof(T).ToString() };
+                    m_Instance = singletonObject.AddComponent<T>();
+
+                    DontDestroyOnLoad(singletonObject);
+                }
+            }
+
+            return m_Instance;
+        }
+    }
+
+    private void OnApplicationQuit()
+    {
+        m_ShuttingDown = true;
+    }
+
+    private void OnDestroy()
+    {
+        m_ShuttingDown = true;
+    }
+}

--- a/Client/Assets/Scripts/Utils/CustomSingleton.cs.meta
+++ b/Client/Assets/Scripts/Utils/CustomSingleton.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d7d9f6137f752394c9c362354563bfa4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# CustomSingleton
- 싱글톤 처리를 상속을 통해 쉽게 구현할 수 있도록 구현했습니다.
- 싱글톤을 직접 구현할 필요 없이 CustomSingleton을 상속 받으면 쉽게 싱글톤 처리가 됩니다.
- 싱글톤 처리된 GameObjcet는 DontDestroyOnLoad() 처리 됩니다.

# 사용 방법

```csharp
public class GameManager : CustomSingleton<GameManager>
{
    protected GameManager() { }

   public void MethodExample() { }
}
```

위와 같이 상속해서 사용하시면 됩니다.
아래와 같이 싱글톤 객체 메서드를 호출할 수 있습니다.

```csharp
GameManager.Instance.MethodExample();
```


# 참고한 자료
- [Unity] C# MonoBehaviour Singleton 유니티 싱글톤 만드는 방법 => [링크](https://ssapo.tistory.com/33)