### PR TITLE
Feature/#44 웹패킷 정의 및 url 수정

### DIFF
--- a/Client/Assets/Scripts/Managers/WebManager.cs
+++ b/Client/Assets/Scripts/Managers/WebManager.cs
@@ -6,7 +6,7 @@ using UnityEngine.Networking;
 
 public class WebManager : CustomSingleton<WebManager>
 {
-    public string BaseUrl { get; set; } = "https://localhost:7074/";
+    public string BaseUrl { get; set; } = "http://116.43.139.10";
 
     public void SendPostRequest<T>(string url, object obj, Action<T> res)
     {

--- a/Client/Assets/Scripts/Web/WebPacket.cs
+++ b/Client/Assets/Scripts/Web/WebPacket.cs
@@ -6,5 +6,5 @@ public class AccountLoginReq
 
 public class AccountLoginRes
 {
-
+    public int LoginOk;
 }

--- a/Server/AccountServer/Controllers/AccountController.cs
+++ b/Server/AccountServer/Controllers/AccountController.cs
@@ -78,12 +78,12 @@ namespace AccountServer.Controllers
                 string accountPassword = account.AccountPassword;
                 if (_passwordEncryptor.IsmatchPassword(reqPassword, accountPassword))
                 {
-                    // ToDo : Response 데이터 처리
-                    //res
+                    res.LoginOk = (int)Define.LoginResult.Success;
                     return res;
                 }
             }
 
+            res.LoginOk = (int)Define.LoginResult.Faile;
             return res;
         }
     }

--- a/Server/AccountServer/DB/WebPacket.cs
+++ b/Server/AccountServer/DB/WebPacket.cs
@@ -18,6 +18,6 @@ namespace AccountServer.DB
 
     public class AccountLoginRes
     {
-
+        public int LoginOk { get; set; }
     }
 }

--- a/Server/AccountServer/Utils/Define.cs
+++ b/Server/AccountServer/Utils/Define.cs
@@ -1,0 +1,11 @@
+﻿namespace AccountServer.Utils
+{
+    public class Define
+    {
+        public enum LoginResult
+        {
+            Faile,
+            Success,
+        }
+    }
+}


### PR DESCRIPTION
# Login 패킷 정의 및 웹앱 url 수정
- AccountLoginRes 클래스를 추가했습니다.
  - Scripts/Web/WebPacket.cs 에 있는 클래스입니다.
- 로그인 관련 url은 <code>account/login</code> 입니다.
- Login 결과는 int 형으로 0은 실패 1은 성공입니다.

# 예시 및 가이드 라인

```csharp
AccountLoginReq req = new AccountLoginReq() { AccountName = "qweqwe", AccountPassword = "qweqwe" };
AccountLoginRes newRes = null;
WebManager.Instance.SendPostRequest<AccountLoginRes>("account/login", req, res =>
{
	newRes = res;
});
```
<br/>

![예시사진1](https://github.com/kminsmin/BlueBlackBlocks/assets/70641418/a03380ca-b209-44c5-b677-161cee415510)


# ❗테스트 시 주의 사항

유니티에서 https가 아니고 http 인 경우에 보안 관련으로 인해서 허용을 하지 않는 문제가 있습니다.
<code>InvalidOperationException: Insecure connection not allowed</code>

아래의 링크를 참고해서 http도 허용 하도록 설정해야 테스트 가능합니다.
=> [참고 블로그 링크](https://cishome.tistory.com/302)